### PR TITLE
Update README clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A production-grade, container-native load balancer built in Go with SSL terminat
 
 1. **Clone and start the stack:**
 ```bash
-git clone <repository-url>
+git clone https://github.com/eltonciatto/VeloFlux.git
 cd veloflux-lb
 docker-compose up -d
 ```


### PR DESCRIPTION
## Summary
- set proper repo URL in Quick Start docs

## Testing
- `go test ./...`
- `npm run lint` *(fails: cannot find '@eslint/js' in eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_684a4174b1248332a1a2df2230fc1533